### PR TITLE
feat: add Turn On, Turn Off, and Enable Auto Mode action cards

### DIFF
--- a/.homeycompose/flow/actions/set-auto-mode2.json
+++ b/.homeycompose/flow/actions/set-auto-mode2.json
@@ -1,0 +1,57 @@
+{
+  "title": {
+    "en": "Enable Auto mode",
+    "nl": "Automatische modus inschakelen",
+    "da": "Aktiver automatisk tilstand",
+    "de": "Automatik-Modus aktivieren",
+    "es": "Activar modo automático",
+    "fr": "Activer le mode automatique",
+    "it": "Abilita modalità automatica",
+    "no": "Aktiver automatisk modus",
+    "sv": "Aktivera automatiskt läge",
+    "pl": "Włącz tryb automatyczny",
+    "ru": "Включить автоматический режим",
+    "ko": "자동 모드 활성화",
+    "ar": "تفعيل الوضع التلقائي"
+  },
+  "titleFormatted": {
+    "en": "Enable Auto mode on [[device]]",
+    "nl": "Schakel automatische modus in op [[device]]",
+    "da": "Aktiver automatisk tilstand på [[device]]",
+    "de": "Automatik-Modus aktivieren auf [[device]]",
+    "es": "Activar modo automático en [[device]]",
+    "fr": "Activer le mode automatique sur [[device]]",
+    "it": "Abilita modalità automatica su [[device]]",
+    "no": "Aktiver automatisk modus på [[device]]",
+    "sv": "Aktivera automatiskt läge på [[device]]",
+    "pl": "Włącz tryb automatyczny na [[device]]",
+    "ru": "Включить автоматический режим на [[device]]",
+    "ko": "[[device]]에서 자동 모드 활성화",
+    "ar": "تفعيل الوضع التلقائي على [[device]]"
+  },
+  "hint": {
+    "en": "Switch to Auto mode. If the device is off, it will be turned on first.",
+    "nl": "Schakel over naar automatische modus. Als het apparaat uit is, wordt het eerst ingeschakeld.",
+    "da": "Skift til automatisk tilstand. Hvis enheden er slukket, tændes den først.",
+    "de": "In den Automatik-Modus wechseln. Ist das Gerät ausgeschaltet, wird es zuerst eingeschaltet.",
+    "es": "Cambiar al modo automático. Si el dispositivo está apagado, se encenderá primero.",
+    "fr": "Passer en mode automatique. Si l'appareil est éteint, il sera d'abord allumé.",
+    "it": "Passa alla modalità automatica. Se il dispositivo è spento, verrà prima acceso.",
+    "no": "Bytt til automatisk modus. Hvis enheten er av, slås den på først.",
+    "sv": "Växla till automatiskt läge. Om enheten är av slås den på först.",
+    "pl": "Przełącz w tryb automatyczny. Jeśli urządzenie jest wyłączone, zostanie najpierw włączone.",
+    "ru": "Переключиться в автоматический режим. Если устройство выключено, оно сначала включится.",
+    "ko": "자동 모드로 전환합니다. 기기가 꺼져 있으면 먼저 켜집니다.",
+    "ar": "التبديل إلى الوضع التلقائي. إذا كان الجهاز مُغلقاً، سيتم تشغيله أولاً."
+  },
+  "platforms": [
+    "local"
+  ],
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "driver_id=dustmagnet|healthprotect|pure|humidifier"
+    }
+  ]
+}

--- a/.homeycompose/flow/actions/set-standby2.json
+++ b/.homeycompose/flow/actions/set-standby2.json
@@ -29,6 +29,21 @@
     "ko": "[[standby]] 대기 모드로 설정",
     "ar": "اضبط وضع الاستعداد على [[standby]]"
   },
+  "hint": {
+    "en": "Note: 'On' wakes the device (running), 'Off' puts it into standby (stopped). Use 'Turn on' / 'Turn off' cards for clearer wording.",
+    "nl": "Let op: 'Aan' wekt het apparaat (actief), 'Uit' zet het in stand-by (gestopt). Gebruik 'Inschakelen' / 'Uitschakelen' voor duidelijkere bewoording.",
+    "da": "Bemærk: 'Til' vågner enheden (kørende), 'Fra' sætter den i standby (stoppet). Brug 'Tænd' / 'Sluk' for klarere ordlyd.",
+    "de": "Hinweis: 'Ein' weckt das Gerät (aktiv), 'Aus' versetzt es in Standby (gestoppt). Verwende 'Einschalten' / 'Ausschalten' für klarere Formulierungen.",
+    "es": "Nota: 'Encendido' despierta el dispositivo (en marcha), 'Apagado' lo pone en espera (detenido). Usa 'Encender' / 'Apagar' para una redacción más clara.",
+    "fr": "Remarque : 'Activé' réveille l'appareil (en marche), 'Désactivé' le met en veille (arrêté). Utilisez 'Allumer' / 'Éteindre' pour une formulation plus claire.",
+    "it": "Nota: 'Acceso' risveglia il dispositivo (in funzione), 'Spento' lo mette in standby (fermato). Usa 'Accendi' / 'Spegni' per una formulazione più chiara.",
+    "no": "Merk: 'På' vekker enheten (kjørende), 'Av' setter den i standby (stoppet). Bruk 'Slå på' / 'Slå av' for klarere ordlyd.",
+    "sv": "Obs: 'På' väcker enheten (aktiv), 'Av' sätter den i standby (stoppad). Använd 'Slå på' / 'Slå av' för tydligare formulering.",
+    "pl": "Uwaga: 'Włącz' wybudza urządzenie (działa), 'Wyłącz' przełącza je w stan czuwania (zatrzymane). Użyj kart 'Włącz' / 'Wyłącz' dla wyraźniejszego opisu.",
+    "ru": "Примечание: 'Вкл' выводит устройство из режима ожидания (работает), 'Выкл' переводит его в режим ожидания (остановлено). Используйте карточки 'Включить' / 'Выключить' для более понятных формулировок.",
+    "ko": "'켜짐'은 기기를 깨웁니다(동작 중), '꺼짐'은 대기 모드로 전환합니다(정지). 더 명확한 표현을 위해 '켜기' / '끄기' 카드를 사용하세요.",
+    "ar": "ملاحظة: 'تشغيل' يوقظ الجهاز (يعمل)، 'إيقاف' يضعه في وضع الاستعداد (متوقف). استخدم بطاقتي 'تشغيل' / 'إيقاف التشغيل' للحصول على صياغة أوضح."
+  },
   "platforms": [
     "local"
   ],
@@ -36,7 +51,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driver_id=dustmagnet|healthprotect|pure"
+      "filter": "driver_id=dustmagnet|healthprotect|pure|humidifier"
     },
     {
       "type": "dropdown",

--- a/.homeycompose/flow/actions/turn-off2.json
+++ b/.homeycompose/flow/actions/turn-off2.json
@@ -1,0 +1,57 @@
+{
+  "title": {
+    "en": "Turn off",
+    "nl": "Uitschakelen",
+    "da": "Sluk",
+    "de": "Ausschalten",
+    "es": "Apagar",
+    "fr": "Éteindre",
+    "it": "Spegni",
+    "no": "Slå av",
+    "sv": "Slå av",
+    "pl": "Wyłącz",
+    "ru": "Выключить",
+    "ko": "끄기",
+    "ar": "إيقاف التشغيل"
+  },
+  "titleFormatted": {
+    "en": "Turn off [[device]]",
+    "nl": "Schakel [[device]] uit",
+    "da": "Sluk [[device]]",
+    "de": "[[device]] ausschalten",
+    "es": "Apagar [[device]]",
+    "fr": "Éteindre [[device]]",
+    "it": "Spegni [[device]]",
+    "no": "Slå av [[device]]",
+    "sv": "Slå av [[device]]",
+    "pl": "Wyłącz [[device]]",
+    "ru": "Выключить [[device]]",
+    "ko": "[[device]] 끄기",
+    "ar": "إيقاف تشغيل [[device]]"
+  },
+  "hint": {
+    "en": "Put the device into standby.",
+    "nl": "Zet het apparaat in stand-by.",
+    "da": "Sæt enheden i standby.",
+    "de": "Gerät in den Standby versetzen.",
+    "es": "Poner el dispositivo en modo de espera.",
+    "fr": "Mettre l'appareil en veille.",
+    "it": "Metti il dispositivo in standby.",
+    "no": "Sett enheten i standby.",
+    "sv": "Sätt enheten i standby.",
+    "pl": "Przełącz urządzenie w stan czuwania.",
+    "ru": "Перевести устройство в режим ожидания.",
+    "ko": "기기를 대기 모드로 전환합니다.",
+    "ar": "وضع الجهاز في وضع الاستعداد."
+  },
+  "platforms": [
+    "local"
+  ],
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "driver_id=dustmagnet|healthprotect|pure|humidifier"
+    }
+  ]
+}

--- a/.homeycompose/flow/actions/turn-on2.json
+++ b/.homeycompose/flow/actions/turn-on2.json
@@ -1,0 +1,57 @@
+{
+  "title": {
+    "en": "Turn on",
+    "nl": "Inschakelen",
+    "da": "Tænd",
+    "de": "Einschalten",
+    "es": "Encender",
+    "fr": "Allumer",
+    "it": "Accendi",
+    "no": "Slå på",
+    "sv": "Slå på",
+    "pl": "Włącz",
+    "ru": "Включить",
+    "ko": "켜기",
+    "ar": "تشغيل"
+  },
+  "titleFormatted": {
+    "en": "Turn on [[device]]",
+    "nl": "Schakel [[device]] in",
+    "da": "Tænd [[device]]",
+    "de": "[[device]] einschalten",
+    "es": "Encender [[device]]",
+    "fr": "Allumer [[device]]",
+    "it": "Accendi [[device]]",
+    "no": "Slå på [[device]]",
+    "sv": "Slå på [[device]]",
+    "pl": "Włącz [[device]]",
+    "ru": "Включить [[device]]",
+    "ko": "[[device]] 켜기",
+    "ar": "تشغيل [[device]]"
+  },
+  "hint": {
+    "en": "Wake the device from standby.",
+    "nl": "Wek het apparaat uit stand-by.",
+    "da": "Vågn enheden fra standby.",
+    "de": "Gerät aus dem Standby aufwecken.",
+    "es": "Despertar el dispositivo del modo de espera.",
+    "fr": "Réveiller l'appareil du mode veille.",
+    "it": "Risveglia il dispositivo dalla standby.",
+    "no": "Vekk enheten fra standby.",
+    "sv": "Väck enheten från standby.",
+    "pl": "Wybudź urządzenie ze stanu czuwania.",
+    "ru": "Вывести устройство из режима ожидания.",
+    "ko": "기기를 대기 모드에서 깨웁니다.",
+    "ar": "إيقاظ الجهاز من وضع الاستعداد."
+  },
+  "platforms": [
+    "local"
+  ],
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": "driver_id=dustmagnet|healthprotect|pure|humidifier"
+    }
+  ]
+}

--- a/drivers/BlueAirAwsBaseDevice.ts
+++ b/drivers/BlueAirAwsBaseDevice.ts
@@ -343,6 +343,56 @@ abstract class BlueAirAwsBaseDevice extends Device {
       throw err;
     }
   }
+
+  public async performTurnOn(): Promise<void> {
+    if (!this.client) throw new Error('Client not initialized');
+    this.logger.info(`action:turn-on → "${this.getName()}"`);
+    try {
+      // standby=false in the API = device is ON (not in standby)
+      await this.client.setStandby(this.getData().uuid, false);
+      // capability standby=true = device is ON
+      this.setCapabilityValue('standby', true).catch(this.error);
+      this.logger.debug('action:turn-on ok');
+    } catch (err) {
+      this.logger.error('action:turn-on failed:', err);
+      throw err;
+    }
+  }
+
+  public async performTurnOff(): Promise<void> {
+    if (!this.client) throw new Error('Client not initialized');
+    this.logger.info(`action:turn-off → "${this.getName()}"`);
+    try {
+      // standby=true in the API = device is IN standby (off)
+      await this.client.setStandby(this.getData().uuid, true);
+      // capability standby=false = device is OFF
+      this.setCapabilityValue('standby', false).catch(this.error);
+      this.logger.debug('action:turn-off ok');
+    } catch (err) {
+      this.logger.error('action:turn-off failed:', err);
+      throw err;
+    }
+  }
+
+  public async performSetAutoMode(): Promise<void> {
+    if (!this.client) throw new Error('Client not initialized');
+    this.logger.info(`action:set-auto-mode → "${this.getName()}"`);
+    try {
+      const isOn = this.getCapabilityValue('standby') as boolean;
+      if (!isOn) {
+        // Device is in standby — wake it first before enabling auto mode
+        this.logger.info('action:set-auto-mode — device is off, waking up first');
+        await this.client.setStandby(this.getData().uuid, false);
+        this.setCapabilityValue('standby', true).catch(this.error);
+      }
+      await this.client.setFanAuto(this.getData().uuid, true);
+      this.setCapabilityValue('automode', true).catch(this.error);
+      this.logger.debug('action:set-auto-mode ok');
+    } catch (err) {
+      this.logger.error('action:set-auto-mode failed:', err);
+      throw err;
+    }
+  }
 }
 
 export default BlueAirAwsBaseDevice;

--- a/drivers/BlueAirAwsFullDevice.ts
+++ b/drivers/BlueAirAwsFullDevice.ts
@@ -295,6 +295,18 @@ abstract class BlueAirAwsFullDevice extends BlueAirAwsBaseDevice {
       await (args.device as BlueAirAwsBaseDevice).performSetChildLock(args.childlock === 'true');
     });
 
+    this.homey.flow.getActionCard('turn-on2').registerRunListener(async (args) => {
+      await (args.device as BlueAirAwsBaseDevice).performTurnOn();
+    });
+
+    this.homey.flow.getActionCard('turn-off2').registerRunListener(async (args) => {
+      await (args.device as BlueAirAwsBaseDevice).performTurnOff();
+    });
+
+    this.homey.flow.getActionCard('set-auto-mode2').registerRunListener(async (args) => {
+      await (args.device as BlueAirAwsBaseDevice).performSetAutoMode();
+    });
+
     if (this.hasCapability('germ_shield')) {
       this.registerCapabilityListener('germ_shield', async (value) => {
         await this.safeSetCommand('germ_shield', () =>

--- a/drivers/humidifier/device.ts
+++ b/drivers/humidifier/device.ts
@@ -159,6 +159,18 @@ class BlueAirHumidifierDevice extends BlueAirAwsBaseDevice {
     this.homey.flow.getActionCard('set-childlock2').registerRunListener(async (args) => {
       await (args.device as BlueAirHumidifierDevice).performSetChildLock(args.childlock === 'true');
     });
+
+    this.homey.flow.getActionCard('turn-on2').registerRunListener(async (args) => {
+      await (args.device as BlueAirHumidifierDevice).performTurnOn();
+    });
+
+    this.homey.flow.getActionCard('turn-off2').registerRunListener(async (args) => {
+      await (args.device as BlueAirHumidifierDevice).performTurnOff();
+    });
+
+    this.homey.flow.getActionCard('set-auto-mode2').registerRunListener(async (args) => {
+      await (args.device as BlueAirHumidifierDevice).performSetAutoMode();
+    });
   }
 
   // ── Lifecycle ─────────────────────────────────────────────────────────────

--- a/drivers/pure/device.ts
+++ b/drivers/pure/device.ts
@@ -154,6 +154,18 @@ class BlueAirPureDevice extends BlueAirAwsBaseDevice {
       await (args.device as BlueAirPureDevice).performSetChildLock(args.childlock === 'true');
     });
 
+    this.homey.flow.getActionCard('turn-on2').registerRunListener(async (args) => {
+      await (args.device as BlueAirPureDevice).performTurnOn();
+    });
+
+    this.homey.flow.getActionCard('turn-off2').registerRunListener(async (args) => {
+      await (args.device as BlueAirPureDevice).performTurnOff();
+    });
+
+    this.homey.flow.getActionCard('set-auto-mode2').registerRunListener(async (args) => {
+      await (args.device as BlueAirPureDevice).performSetAutoMode();
+    });
+
     // Condition card
     this.homey.flow.getConditionCard('score_pm25').registerRunListener(async (args) =>
       conditionScorePm25ToString(this.getCapabilityValue('measure_pm25')) === args.argument_main


### PR DESCRIPTION
## Summary

Addresses user feedback that the standby action card UX is confusing — setting standby to "On" to turn the purifier *off* is counter-intuitive, and switching to Auto mode while off requires two separate cards.

- **`turn-on2`** — single-action card that wakes the device from standby. No args, plain label.
- **`turn-off2`** — single-action card that puts the device into standby. No args, plain label.
- **`set-auto-mode2`** — enables Auto mode, and if the device is currently off (standby), wakes it first in the same action. Replaces the two-card workaround.
- **`set-standby2`** (existing) — updated with a `hint` explaining the inverted On/Off semantics, and adds `humidifier` to its driver filter (the listener was already registered but the filter was missing it).

All four cards cover `dustmagnet|healthprotect|pure|humidifier`. All 13 locales included (`en sv nl da de es fr it no pl ru ko ar`). Build is clean.

### New `performSet*` methods in `BlueAirAwsBaseDevice`
- `performTurnOn()` — calls `client.setStandby(uuid, false)`, sets `standby=true`
- `performTurnOff()` — calls `client.setStandby(uuid, true)`, sets `standby=false`
- `performSetAutoMode()` — conditionally wakes device then calls `client.setFanAuto(uuid, true)`

Existing `set-standby2` card and `performSetStandby` are untouched — no breaking change for existing flows.

## Test plan

- [ ] Flow editor shows "Turn on", "Turn off", and "Enable Auto mode" cards for all four driver types
- [ ] "Turn on" card wakes a device that is in standby
- [ ] "Turn off" card puts a running device into standby
- [ ] "Enable Auto mode" on a running device enables auto mode without changing power state
- [ ] "Enable Auto mode" on a stopped device turns it on first, then enables auto mode
- [ ] Existing flows using `set-standby2` continue to work unchanged
- [ ] `set-standby2` card shows the new hint text in the flow editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)