### PR TITLE
fix: add 'authentication' keyword to re-auth trigger list (Sentry HOMEY-BLUEAIR-T)

### DIFF
--- a/drivers/BlueAirAwsBaseDevice.ts
+++ b/drivers/BlueAirAwsBaseDevice.ts
@@ -204,7 +204,8 @@ abstract class BlueAirAwsBaseDevice extends Device {
       msg.includes('unauthorized') ||
       msg.includes('gigya') ||
       msg.includes('token') ||
-      msg.includes('invalid')
+      msg.includes('invalid') ||
+      msg.includes('authentication')
     ) {
       if (!this.client) return;
       this.logger.info('auth/session error — attempting re-authentication...');


### PR DESCRIPTION
## Root cause

`blueairaws-client` throws this error on 401/403 API responses:
```javascript
throw new Error(`Authentication failed: ${error.response.data.message}`);
```
When `error.response.data.message` is absent, the error message becomes `"Authentication failed: undefined"`.

Our `onPollFailure` re-auth check matched on keywords like `'401'`, `'403'`, `'unauthorized'` etc. — but **the status codes don't appear in the thrown message string**, and `'authentication'` was not in the list. So the keyword check never matched this error class, re-auth was never attempted, and the device burned through all 3 consecutive failures before being marked unavailable.

## Fix

Add `'authentication'` to the keyword list in `onPollFailure`. The string `"authentication failed: undefined"` now matches, triggering `client.initialize()` re-auth on the first occurrence instead of failing silently.

## One-line diff

```typescript
msg.includes('invalid') ||
+ msg.includes('authentication')   // catches "Authentication failed: undefined" (Sentry HOMEY-BLUEAIR-T)
```

## Test plan
- [ ] Simulate a 401 response from the API — device should attempt re-auth rather than going unavailable after 3 polls
- [ ] Verify Sentry HOMEY-BLUEAIR-T stops recurring after this ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)