### PR TITLE
fix: clear cached rejected client promise on init failure

### DIFF
--- a/drivers/BlueAirAwsBaseDevice.ts
+++ b/drivers/BlueAirAwsBaseDevice.ts
@@ -138,7 +138,8 @@ abstract class BlueAirAwsBaseDevice extends Device {
 
       this.logger.info(`initialized (poll every ${pollMs / 1000}s)`);
     } catch (e) {
-      // Device cannot start at all — report to Sentry so it's visible
+      // Clear the cached client so the next init attempt creates a fresh one
+      (this.driver as BlueAirAwsBaseDriver).clearClient(settings.username as string);
       this.logger.critical('Initialization failed', e, { deviceId: data.uuid });
       this.setUnavailable('Initialization failed').catch(this.error);
     }

--- a/drivers/BlueAirAwsBaseDriver.ts
+++ b/drivers/BlueAirAwsBaseDriver.ts
@@ -19,7 +19,12 @@ abstract class BlueAirAwsBaseDriver extends Driver {
         const client = new BlueAirAwsClient(username, password);
         await client.initialize();
         return client;
-      })();
+      })().catch((err) => {
+        // Remove the rejected promise so the next call retries fresh
+        // instead of returning a permanently-cached rejection.
+        this._clientPromises.delete(username);
+        throw err;
+      });
       this._clientPromises.set(username, promise);
     }
     return this._clientPromises.get(username)!;


### PR DESCRIPTION
## Problem

When `client.initialize()` threw (e.g. "Authentication failed: undefined"), the rejected promise was stored permanently in `_clientPromises`. Two consequences:

1. **Unhandled rejection in Sentry** — Node.js could flag the cached rejection as unhandled before a new awaiter attached its catch handler on the next reinit attempt. This is why Sentry captures the error at `process.processTicksAndRejections` level without device context (no `app.version`/`device.name` tags, `level: error` not `critical`).

2. **Stuck reinit loop** — if Homey tried to reinitialize the device within the same app session, `getOrCreateClient` returned the same already-rejected promise immediately, providing no opportunity for the credentials or API to recover.

## Fix

**`BlueAirAwsBaseDriver.getOrCreateClient`** — attach `.catch()` that deletes the map entry on rejection, so the next call always creates a fresh `BlueAirAwsClient`:

```typescript
})().catch((err) => {
  this._clientPromises.delete(username);
  throw err;
});
```

**`BlueAirAwsBaseDevice.onInit` catch block** — explicitly call `clearClient()` as a safety net for race conditions where a concurrent caller may have received the pending promise before it rejected:

```typescript
} catch (e) {
  (this.driver as BlueAirAwsBaseDriver).clearClient(settings.username as string);
  this.logger.critical('Initialization failed', e, { deviceId: data.uuid });
  ...
}
```

## Related
Companion to PR #11 (merged) which added `'authentication'` to the re-auth keyword list.

## Test plan
- [ ] Simulate bad credentials → device goes unavailable
- [ ] Fix credentials in settings → next init creates fresh client (no cached rejection)
- [ ] Sentry stops capturing unhandled rejections without device context

🤖 Generated with [Claude Code](https://claude.com/claude-code)